### PR TITLE
Replace deprecated method '.initEvent()' with CustomEvent()

### DIFF
--- a/lib/assets/javascripts/turbolinks/helpers.coffee
+++ b/lib/assets/javascripts/turbolinks/helpers.coffee
@@ -22,8 +22,10 @@ Turbolinks.defer = (callback) ->
 
 
 Turbolinks.dispatch = (eventName, {target, cancelable, data} = {}) ->
-  event = document.createEvent("Events")
-  event.initEvent(eventName, true, cancelable is true)
+  event = new CustomEvent(eventName,
+    bubbles: true, 
+    cancelable: cancelable is true
+  )
   event.data = data
   (target ? document).dispatchEvent(event)
   event


### PR DESCRIPTION
I noticed that in the helper file, a deprecated method is used, so I replaced it with CustomEvent.

initEvent()
https://developer.mozilla.org/en-US/docs/Web/API/Event/initEvent  

CustomEvent()
https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent

The part I am kind of uncomfortable with is the fact that it uses ".data" to store the data. I like the name ".data", but it is convention in CustomEvent to store things in ".detail". What does everybody think?   
