### PR TITLE
Ignore initial popstate event

### DIFF
--- a/lib/assets/javascripts/turbolinks/history.coffee
+++ b/lib/assets/javascripts/turbolinks/history.coffee
@@ -1,3 +1,9 @@
+pageLoaded = false
+
+addEventListener "load", ->
+  Turbolinks.defer ->
+    pageLoaded = true
+
 class Turbolinks.History
   constructor: (@delegate) ->
 
@@ -22,12 +28,17 @@ class Turbolinks.History
   # Event handlers
 
   onPopState: (event) =>
-    if turbolinks = event.state?.turbolinks
-      location = Turbolinks.Location.box(window.location)
-      restorationIdentifier = turbolinks.restorationIdentifier
-      @delegate.historyPoppedToLocationWithRestorationIdentifier(location, restorationIdentifier)
+    if @shouldHandlePopState()
+      if turbolinks = event.state?.turbolinks
+        location = Turbolinks.Location.box(window.location)
+        restorationIdentifier = turbolinks.restorationIdentifier
+        @delegate.historyPoppedToLocationWithRestorationIdentifier(location, restorationIdentifier)
 
   # Private
+
+  shouldHandlePopState: ->
+    # Safari dispatches a popstate event after window's load event, ignore it
+    pageLoaded is true
 
   update: (method, location, restorationIdentifier) ->
     state = turbolinks: {restorationIdentifier}


### PR DESCRIPTION
> Browsers tend to handle the popstate event differently on page load. Chrome (prior to v34) and Safari always emit a popstate event on page load, but Firefox doesn't.

https://developer.mozilla.org/en-US/docs/Web/Events/popstate