### PR TITLE
Annotate <html> with CSS class names so apps can easily infer and react to loading state

### DIFF
--- a/lib/assets/javascripts/turbolinks/browser_adapter.coffee
+++ b/lib/assets/javascripts/turbolinks/browser_adapter.coffee
@@ -3,6 +3,10 @@
 class Turbolinks.BrowserAdapter
   PROGRESS_BAR_DELAY = 500
 
+  ANNOTATION_CLASS_NAMES =
+    snapshot: "turbolinks-snapshot"
+    loading: "turbolinks-loading"
+
   constructor: (@controller) ->
     @progressBar = new Turbolinks.ProgressBar
 
@@ -12,9 +16,11 @@ class Turbolinks.BrowserAdapter
   visitStarted: (visit) ->
     visit.changeHistory()
     visit.issueRequest()
-    visit.restoreSnapshot()
+    if visit.restoreSnapshot()
+      @annotateDocument("snapshot")
 
   visitRequestStarted: (visit) ->
+    @annotateDocument("loading")
     @progressBar.setValue(0)
     unless visit.snapshotRestored
       if visit.hasSnapshot() or visit.action isnt "restore"
@@ -36,6 +42,7 @@ class Turbolinks.BrowserAdapter
         visit.loadResponse()
 
   visitRequestFinished: (visit) ->
+    @removeDocumentAnnotations()
     @hideProgressBar()
 
   visitResponseLoaded: (visit) ->
@@ -55,6 +62,15 @@ class Turbolinks.BrowserAdapter
   hideProgressBar: ->
     @progressBar.hide()
     clearTimeout(@progressBarTimeout)
+
+  annotateDocument: (annotation) ->
+    className = ANNOTATION_CLASS_NAMES[annotation]
+    document.documentElement.classList.add(className)
+
+  removeDocumentAnnotations: ->
+    for key, className of ANNOTATION_CLASS_NAMES
+      document.documentElement.classList.remove(className)
+    return
 
   reload: ->
     window.location.reload()

--- a/lib/assets/javascripts/turbolinks/browser_adapter.coffee
+++ b/lib/assets/javascripts/turbolinks/browser_adapter.coffee
@@ -3,10 +3,6 @@
 class Turbolinks.BrowserAdapter
   PROGRESS_BAR_DELAY = 500
 
-  ANNOTATION_CLASS_NAMES =
-    snapshot: "turbolinks-snapshot"
-    loading: "turbolinks-loading"
-
   constructor: (@controller) ->
     @progressBar = new Turbolinks.ProgressBar
 
@@ -16,11 +12,9 @@ class Turbolinks.BrowserAdapter
   visitStarted: (visit) ->
     visit.changeHistory()
     visit.issueRequest()
-    if visit.restoreSnapshot()
-      @annotateDocument("snapshot")
+    visit.restoreSnapshot()
 
   visitRequestStarted: (visit) ->
-    @annotateDocument("loading")
     @progressBar.setValue(0)
     unless visit.snapshotRestored
       if visit.hasSnapshot() or visit.action isnt "restore"
@@ -42,7 +36,6 @@ class Turbolinks.BrowserAdapter
         visit.loadResponse()
 
   visitRequestFinished: (visit) ->
-    @removeDocumentAnnotations()
     @hideProgressBar()
 
   visitResponseLoaded: (visit) ->
@@ -62,15 +55,6 @@ class Turbolinks.BrowserAdapter
   hideProgressBar: ->
     @progressBar.hide()
     clearTimeout(@progressBarTimeout)
-
-  annotateDocument: (annotation) ->
-    className = ANNOTATION_CLASS_NAMES[annotation]
-    document.documentElement.classList.add(className)
-
-  removeDocumentAnnotations: ->
-    for key, className of ANNOTATION_CLASS_NAMES
-      document.documentElement.classList.remove(className)
-    return
 
   reload: ->
     window.location.reload()


### PR DESCRIPTION
* Adds  `turbolinks-loading` class to `<html>` while a request is in progress
* Adds `turbolinks-snapshot` class to `<html>` while displaying a snapshot